### PR TITLE
Tool shortcuts

### DIFF
--- a/Source/Edit tool scripts/EditShape.cs
+++ b/Source/Edit tool scripts/EditShape.cs
@@ -54,10 +54,10 @@ namespace iffnsStuff.MarchingCubeEditor.EditTools
         {
             // ToDo: Find better way to set it up once
             shortcutHandlers.Clear();
-            SetupShortcutHanlders();
+            SetupShortcutHandlers();
         }
 
-        protected virtual void SetupShortcutHanlders()
+        protected virtual void SetupShortcutHandlers()
         {
             shortcutHandlers.Add(new HandleScaleByHoldingSAndScrolling(transform));
         }

--- a/Source/Edit tool scripts/EditShape.cs
+++ b/Source/Edit tool scripts/EditShape.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 
 namespace iffnsStuff.MarchingCubeEditor.EditTools
 {
+    [ExecuteInEditMode]
     public abstract class EditShape : MonoBehaviour
     {
         private Matrix4x4 worldToLocalMatrix;

--- a/Source/Edit tool scripts/EditShape.cs
+++ b/Source/Edit tool scripts/EditShape.cs
@@ -1,6 +1,7 @@
 #if UNITY_EDITOR
 
 using UnityEditor;
+using UnityEditor.Experimental.GraphView;
 using UnityEngine;
 
 namespace iffnsStuff.MarchingCubeEditor.EditTools
@@ -45,6 +46,63 @@ namespace iffnsStuff.MarchingCubeEditor.EditTools
         /// Material linked to the shape for visualization.
         /// </summary>
         [SerializeField] private Material linkedMaterial;
+
+        public void DrawUI()
+        {
+            EditorGUILayout.HelpBox("Controls:\n" +
+                    "Click to add\n" +
+                    "Ctrl Click to subtract\n" +
+                    "Shift Scroll to scale", MessageType.None);
+        }
+
+        KeyCode scaleKey = KeyCode.S;
+        bool scaleActive = false;
+
+        protected void HandleScaleByHoldingSAndScrolling(Event e)
+        {
+            if (e.keyCode == scaleKey)
+            {
+                if (e.type == EventType.KeyDown) scaleActive = true;
+                else if (e.type == EventType.KeyUp) scaleActive = false;
+            }
+
+            if (scaleActive && e.type == EventType.ScrollWheel)
+            {
+                Debug.Log($"Scaling with factor {e.delta}");
+
+                float scaleDelta = e.delta.y * -0.03f; // Scale factor; reverse direction if needed
+
+                transform.localScale *= (scaleDelta + 1);
+
+                e.Use(); // Mark event as handled
+            }
+        }
+
+        /*
+        ShortcutHandler handleScaleByHoldingSAndScrolling = new ShortcutHandler(
+                "Hold S and scroll to scale",
+                HandleScaleByHoldingSAndScrolling
+            );
+        */
+
+        public virtual void HandleSceneUpdate(Event e)
+        {
+            HandleScaleByHoldingSAndScrolling(e);
+        }
+
+        protected class ShortcutHandler
+        {
+            string shortcutDescription;
+            public delegate void HanldeShortcutsDelegate(Event e);
+
+            HanldeShortcutsDelegate handler;
+
+            public ShortcutHandler(string shortcutDescription, HanldeShortcutsDelegate handler)
+            {
+                this.shortcutDescription = shortcutDescription;
+                this.handler = handler;
+            }
+        }
 
         public Color Color
         {

--- a/Source/Edit tool scripts/EditShape.cs
+++ b/Source/Edit tool scripts/EditShape.cs
@@ -52,7 +52,11 @@ namespace iffnsStuff.MarchingCubeEditor.EditTools
 
         void OnEnable()
         {
-            // ToDo: Find better way to set it up once
+            Initialize();
+        }
+
+        public void Initialize()
+        {
             shortcutHandlers.Clear();
             SetupShortcutHandlers();
         }

--- a/Source/Edit tool scripts/EditShape.cs
+++ b/Source/Edit tool scripts/EditShape.cs
@@ -65,6 +65,7 @@ namespace iffnsStuff.MarchingCubeEditor.EditTools
         public void DrawUI()
         {
             string helpText = "Controls:\n" +
+                    "Note that the scene has to be active for some of these to work.\n"+
                     "Click to add\n" +
                     "Ctrl Click to subtract";
 

--- a/Source/Edit tool scripts/EditShape.cs
+++ b/Source/Edit tool scripts/EditShape.cs
@@ -50,7 +50,7 @@ namespace iffnsStuff.MarchingCubeEditor.EditTools
 
         readonly List<ShortcutHandler> shortcutHandlers = new List<ShortcutHandler>();
 
-        private void OnEnable()
+        void OnEnable()
         {
             // ToDo: Find better way to set it up once
             shortcutHandlers.Clear();
@@ -66,8 +66,7 @@ namespace iffnsStuff.MarchingCubeEditor.EditTools
         {
             string helpText = "Controls:\n" +
                     "Click to add\n" +
-                    "Ctrl Click to subtract\n" +
-                    "Shift Scroll to scale";
+                    "Ctrl Click to subtract\n";
 
             foreach(ShortcutHandler handler in shortcutHandlers)
             {

--- a/Source/Edit tool scripts/EditShape.cs
+++ b/Source/Edit tool scripts/EditShape.cs
@@ -66,7 +66,7 @@ namespace iffnsStuff.MarchingCubeEditor.EditTools
         {
             string helpText = "Controls:\n" +
                     "Click to add\n" +
-                    "Ctrl Click to subtract\n";
+                    "Ctrl Click to subtract";
 
             foreach(ShortcutHandler handler in shortcutHandlers)
             {

--- a/Source/Edit tool scripts/ShortcutHandler.cs
+++ b/Source/Edit tool scripts/ShortcutHandler.cs
@@ -31,9 +31,7 @@ public class HandleScaleByHoldingSAndScrolling : ShortcutHandler
 
         if (scaleActive && e.type == EventType.ScrollWheel)
         {
-            Debug.Log($"Scaling with factor {e.delta}");
-
-            float scaleDelta = e.delta.y * -0.03f; // Scale factor; reverse direction if needed
+            float scaleDelta = e.delta.y * 0.03f; // Scale factor; reverse direction if needed
 
             referenceTransform.localScale *= (scaleDelta + 1);
 
@@ -67,7 +65,7 @@ public class HandleHorizontalScaleByHoldingSAndScrolling : ShortcutHandler
         {
             Debug.Log($"Scaling with factor {e.delta}");
 
-            float scaleDelta = e.delta.x * -0.03f; // Scale factor; reverse direction if needed
+            float scaleDelta = e.delta.x * 0.03f; // Scale factor; reverse direction if needed
 
             float scaleFactor = scaleDelta + 1;
 

--- a/Source/Edit tool scripts/ShortcutHandler.cs
+++ b/Source/Edit tool scripts/ShortcutHandler.cs
@@ -1,0 +1,44 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+#if UNITY_EDITOR
+public abstract class ShortcutHandler
+{
+    public abstract string ShortcutText { get; }
+    public abstract void HandleShortcut(Event e);
+}
+
+public class HandleScaleByHoldingSAndScrolling : ShortcutHandler
+{
+    readonly Transform referenceTransform;
+    KeyCode scaleKey = KeyCode.S;
+    bool scaleActive = false;
+
+    public HandleScaleByHoldingSAndScrolling(Transform referenceTransform)
+    {
+        this.referenceTransform = referenceTransform;
+    }
+
+    public override string ShortcutText { get { return $"Hold {scaleKey} and scroll to change the size"; } }
+
+    public override void HandleShortcut(Event e)
+    {
+        if (e.keyCode == scaleKey)
+        {
+            if (e.type == EventType.KeyDown) scaleActive = true;
+            else if (e.type == EventType.KeyUp) scaleActive = false;
+        }
+
+        if (scaleActive && e.type == EventType.ScrollWheel)
+        {
+            Debug.Log($"Scaling with factor {e.delta}");
+
+            float scaleDelta = e.delta.y * -0.03f; // Scale factor; reverse direction if needed
+
+            referenceTransform.localScale *= (scaleDelta + 1);
+
+            e.Use(); // Mark event as handled
+        }
+    }
+}
+#endif

--- a/Source/Edit tool scripts/ShortcutHandler.cs
+++ b/Source/Edit tool scripts/ShortcutHandler.cs
@@ -1,11 +1,20 @@
 using System.Collections;
 using System.Collections.Generic;
+using UnityEditor;
 using UnityEngine;
 #if UNITY_EDITOR
 public abstract class ShortcutHandler
 {
     public abstract string ShortcutText { get; }
     public abstract void HandleShortcut(Event e);
+
+    protected void ForceSceneFocus()
+    {
+        if (SceneView.lastActiveSceneView != null)
+        {
+            SceneView.lastActiveSceneView.Focus(); // Make sure that the scene is the focus
+        }
+    }
 }
 
 public class HandleScaleByHoldingSAndScrolling : ShortcutHandler
@@ -23,6 +32,8 @@ public class HandleScaleByHoldingSAndScrolling : ShortcutHandler
 
     public override void HandleShortcut(Event e)
     {
+        ForceSceneFocus();
+
         if (e.keyCode == scaleKey)
         {
             if (e.type == EventType.KeyDown) scaleActive = true;
@@ -55,6 +66,8 @@ public class HandleHorizontalScaleByHoldingSAndScrolling : ShortcutHandler
 
     public override void HandleShortcut(Event e)
     {
+        ForceSceneFocus();
+
         if (e.keyCode == scaleKey)
         {
             if (e.type == EventType.KeyDown) scaleActive = true;

--- a/Source/Edit tool scripts/ShortcutHandler.cs
+++ b/Source/Edit tool scripts/ShortcutHandler.cs
@@ -41,4 +41,44 @@ public class HandleScaleByHoldingSAndScrolling : ShortcutHandler
         }
     }
 }
+
+public class HandleHorizontalScaleByHoldingSAndScrolling : ShortcutHandler
+{
+    readonly Transform referenceTransform;
+    KeyCode scaleKey = KeyCode.S;
+    bool scaleActive = false;
+
+    public HandleHorizontalScaleByHoldingSAndScrolling(Transform referenceTransform)
+    {
+        this.referenceTransform = referenceTransform;
+    }
+
+    public override string ShortcutText { get { return $"Hold {scaleKey} and scroll to change the size"; } }
+
+    public override void HandleShortcut(Event e)
+    {
+        if (e.keyCode == scaleKey)
+        {
+            if (e.type == EventType.KeyDown) scaleActive = true;
+            else if (e.type == EventType.KeyUp) scaleActive = false;
+        }
+
+        if (scaleActive && e.type == EventType.ScrollWheel)
+        {
+            Debug.Log($"Scaling with factor {e.delta}");
+
+            float scaleDelta = e.delta.x * -0.03f; // Scale factor; reverse direction if needed
+
+            float scaleFactor = scaleDelta + 1;
+
+            referenceTransform.localScale = new Vector3(
+                referenceTransform.localScale.x * scaleFactor,
+                referenceTransform.localScale.y,
+                referenceTransform.localScale.z * scaleFactor
+                );
+
+            e.Use(); // Mark event as handled
+        }
+    }
+}
 #endif

--- a/Source/Edit tool scripts/ShortcutHandler.cs
+++ b/Source/Edit tool scripts/ShortcutHandler.cs
@@ -7,14 +7,6 @@ public abstract class ShortcutHandler
 {
     public abstract string ShortcutText { get; }
     public abstract void HandleShortcut(Event e);
-
-    protected void ForceSceneFocus()
-    {
-        if (SceneView.lastActiveSceneView != null)
-        {
-            SceneView.lastActiveSceneView.Focus(); // Make sure that the scene is the focus
-        }
-    }
 }
 
 public class HandleScaleByHoldingSAndScrolling : ShortcutHandler
@@ -32,8 +24,6 @@ public class HandleScaleByHoldingSAndScrolling : ShortcutHandler
 
     public override void HandleShortcut(Event e)
     {
-        ForceSceneFocus();
-
         if (e.keyCode == scaleKey)
         {
             if (e.type == EventType.KeyDown) scaleActive = true;
@@ -66,8 +56,6 @@ public class HandleHorizontalScaleByHoldingSAndScrolling : ShortcutHandler
 
     public override void HandleShortcut(Event e)
     {
-        ForceSceneFocus();
-
         if (e.keyCode == scaleKey)
         {
             if (e.type == EventType.KeyDown) scaleActive = true;

--- a/Source/Edit tool scripts/ShortcutHandler.cs.meta
+++ b/Source/Edit tool scripts/ShortcutHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8082f4385f693b499f884ccca989458
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Source/EditorTools/SimpleClickToModifyTool.cs
+++ b/Source/EditorTools/SimpleClickToModifyTool.cs
@@ -73,7 +73,7 @@ public class SimpleClickToModifyTool : BaseTool
 
         RayHitResult result = LinkedMarchingCubeEditor.RaycastAtMousePosition(e);
 
-        if(result != RayHitResult.None)
+        if (result != RayHitResult.None)
         {
             selectedShape.transform.position = result.point;
 
@@ -95,6 +95,14 @@ public class SimpleClickToModifyTool : BaseTool
         }
 
         if (selectedShape) selectedShape.HandleSceneUpdate(e);
+
+        //Press escape to cancel
+        if (e.type == EventType.KeyDown && e.keyCode == KeyCode.Escape)
+        {
+            raycastActive = false;
+            e.Use();
+            return;
+        }
     }
 
     public override void DrawGizmos()

--- a/Source/EditorTools/SimpleClickToModifyTool.cs
+++ b/Source/EditorTools/SimpleClickToModifyTool.cs
@@ -15,17 +15,6 @@ public class SimpleClickToModifyTool : BaseTool
             selectedShape.gameObject.SetActive(false);
             LinkedMarchingCubeController.DisplayPreviewShape = false;
             LinkedMarchingCubeController.EnableAllColliders = value;
-            if (value)
-            {
-                EditorApplication.delayCall += () =>
-                {
-                    if (SceneView.lastActiveSceneView != null)
-                    {
-                        Debug.Log("Activating");
-                        SceneView.lastActiveSceneView.Focus(); // Set the scene as focus
-                    }
-                };
-            }
             raycastActive = value;
         }
     }

--- a/Source/EditorTools/SimpleClickToModifyTool.cs
+++ b/Source/EditorTools/SimpleClickToModifyTool.cs
@@ -63,10 +63,7 @@ public class SimpleClickToModifyTool : BaseTool
 
         if (raycastActive)
         {
-            EditorGUILayout.HelpBox("Controls:\n" +
-                    "Click to add\n" +
-                    "Ctrl Click to subtract\n" +
-                    "Shift Scroll to scale", MessageType.None);
+            selectedShape.DrawUI();
         }
     }
 
@@ -97,14 +94,7 @@ public class SimpleClickToModifyTool : BaseTool
             LinkedMarchingCubeController.DisplayPreviewShape = false;
         }
 
-        if (e.shift && e.type == EventType.ScrollWheel)
-        {
-            float scaleDelta = e.delta.x * -0.03f; // Scale factor; reverse direction if needed
-
-            selectedShape.transform.localScale *= (scaleDelta + 1);
-
-            e.Use(); // Mark event as handled
-        }
+        if (selectedShape) selectedShape.HandleSceneUpdate(e);
     }
 
     public override void DrawGizmos()

--- a/Source/EditorTools/SimpleClickToModifyTool.cs
+++ b/Source/EditorTools/SimpleClickToModifyTool.cs
@@ -10,12 +10,22 @@ public class SimpleClickToModifyTool : BaseTool
     bool raycastActive;
     bool RaycastActive
     {
-        get => raycastActive;
         set
         {
             selectedShape.gameObject.SetActive(false);
             LinkedMarchingCubeController.DisplayPreviewShape = false;
             LinkedMarchingCubeController.EnableAllColliders = value;
+            if (value)
+            {
+                EditorApplication.delayCall += () =>
+                {
+                    if (SceneView.lastActiveSceneView != null)
+                    {
+                        Debug.Log("Activating");
+                        SceneView.lastActiveSceneView.Focus(); // Set the scene as focus
+                    }
+                };
+            }
             raycastActive = value;
         }
     }

--- a/Source/EditorTools/SimpleClickToModifyTool.cs
+++ b/Source/EditorTools/SimpleClickToModifyTool.cs
@@ -47,6 +47,7 @@ public class SimpleClickToModifyTool : BaseTool
             RestoreShapePositionIfAble();
             selectedShape = newSelectedShape;
             SaveShapePositionIfAble();
+            newSelectedShape.Initialize();
         }
 
         if (!newSelectedShape) RestoreShapePositionIfAble();

--- a/Source/EditorTools/SimpleClickToModifyTool.cs
+++ b/Source/EditorTools/SimpleClickToModifyTool.cs
@@ -1,7 +1,6 @@
 #if UNITY_EDITOR
 
 using iffnsStuff.MarchingCubeEditor.EditTools;
-using iffnsStuff.MarchingCubeEditor.SceneEditor;
 using UnityEditor;
 using UnityEngine;
 
@@ -9,6 +8,18 @@ public class SimpleClickToModifyTool : BaseTool
 {
     EditShape selectedShape;
     bool raycastActive;
+    bool RaycastActive
+    {
+        get => raycastActive;
+        set
+        {
+            selectedShape.gameObject.SetActive(false);
+            LinkedMarchingCubeController.DisplayPreviewShape = false;
+            LinkedMarchingCubeController.EnableAllColliders = value;
+            raycastActive = value;
+        }
+    }
+
     bool displayPreviewShape;
     Vector3 originalShapePosition;
 
@@ -47,10 +58,7 @@ public class SimpleClickToModifyTool : BaseTool
         bool newRaycastActive = EditorGUILayout.Toggle("Active", raycastActive);
         if(raycastActive != newRaycastActive)
         {
-            selectedShape.gameObject.SetActive(false);
-            LinkedMarchingCubeController.DisplayPreviewShape = false;
-            LinkedMarchingCubeController.EnableAllColliders = newRaycastActive;
-            raycastActive = newRaycastActive;
+            RaycastActive = newRaycastActive;
         }
 
         bool newDisplayPreviewShape = EditorGUILayout.Toggle("Display preview shape", displayPreviewShape);
@@ -99,7 +107,7 @@ public class SimpleClickToModifyTool : BaseTool
         //Press escape to cancel
         if (e.type == EventType.KeyDown && e.keyCode == KeyCode.Escape)
         {
-            raycastActive = false;
+            RaycastActive = false;
             e.Use();
             return;
         }

--- a/Source/EditorTools/SimpleClickToPaintTool.cs
+++ b/Source/EditorTools/SimpleClickToPaintTool.cs
@@ -45,6 +45,7 @@ public class SimpleClickToPaintTool : BaseTool
             RestoreShapePositionIfAble();
             selectedShape = newSelectedShape;
             SaveShapePositionIfAble();
+            newSelectedShape.Initialize();
         }
 
         if (!newSelectedShape) RestoreShapePositionIfAble();

--- a/Source/EditorTools/SimpleSceneModifyTool.cs
+++ b/Source/EditorTools/SimpleSceneModifyTool.cs
@@ -14,10 +14,15 @@ public class SimpleSceneModifyTool : BaseTool
 
     public override void DrawUI()
     {
-        selectedShape = EditorGUILayout.ObjectField(
+        EditShape newSelectedShape = EditorGUILayout.ObjectField(
             selectedShape,
             typeof(EditShape),
             true) as EditShape;
+
+        if (newSelectedShape && newSelectedShape != selectedShape)
+        {
+            newSelectedShape.Initialize();
+        }
 
         if (selectedShape)
         {


### PR DESCRIPTION
Implemented tool specific shortcuts:
- The different shapes now have the ability to define their own shortcuts
- The `EditShape` class has an initial shortcut combination, where holding S and scrolling changes the size.
- New derived shapes can add expand the shortcuts redefine all.
- The shortcut functions have been implemented as classes which can be reused.
- Each class also has a string description that is automatically displayed.

Additional additions:
- Press escape to cancel editing.

To note about the implementation:
- This currently focuses on the `SimpleClickToModifyTool` implementation.
- `[ExecuteInEditMode]` had to be added to `EditShape` in order to make it work.
- Each `ShortcutHandler` class has the ability to take the scene focus. This disables the ability to use the rest of the Unity UI as long as the tool is active. Otherwise, the scene would first have to be activated (For example by right clicking) in order to make the shortcut work.
